### PR TITLE
Fix vault configuration

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -344,12 +344,12 @@ async function run() {
     await Deno.writeTextFile(walkEntry.path, withoutLogbooks);
   }
 
-  if (!existsSync(".obsidian/app.json")) {
-    Deno.createSync(".obsidian/app.json");
-    Deno.writeTextFileSync(".obsidian/app.json", "{}");
+  if (!existsSync(output + ".obsidian/app.json")) {
+    Deno.createSync(output + ".obsidian/app.json");
+    Deno.writeTextFileSync(output + ".obsidian/app.json", "{}");
   }
 
-  await updateConfigForLogseqStructure(".obsidian/app.json");
+  await updateConfigForLogseqStructure(output + ".obsidian/app.json");
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
Tries to fix:
```
error: Uncaught (in promise) NotFound: No such file or directory (os error 2): open '.obsidian/app.json'
    Deno.createSync(".obsidian/app.json");
         ^
    at openSync (ext:deno_fs/30_fs.js:528:15)
```
I assume the intention is to check for an existing config in the output folder